### PR TITLE
Better not expose the BeanFactory as a bean itself

### DIFF
--- a/src/Config/AppConfiguration.php
+++ b/src/Config/AppConfiguration.php
@@ -29,15 +29,6 @@ class AppConfiguration
 {
     /**
      * @Bean
-     * @return ContainerInterface
-     */
-    protected function container(): ContainerInterface
-    {
-        return BeanFactoryRegistry::getInstance();
-    }
-
-    /**
-     * @Bean
      * @Parameters({
      *  @Parameter({"name" = "config"})
      * })
@@ -68,7 +59,7 @@ class AppConfiguration
         }
 
         $containerChain = new ContainerChain(
-            $this->container(),
+            BeanFactoryRegistry::getInstance(),
             new EventMachineContainer($eventMachine)
         );
 


### PR DESCRIPTION
Whilst technically it should be possible to expose the BeanFactory internally as a bean, I would advise against it to avoid side-effects to due singleton handling and such. In theory it should work, but I would not rely on the functionality.

If you want to extract the registry call to a single method, simply use a private method as those are ignored by Disco and act as "normal" methods.