### PR TITLE
Updated README to use composer create-project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ Dockerized skeleton for prooph software [Event Machine](https://github.com/proop
 ## Installation
 
 ```bash
-$ git clone git@github.com:proophsoftware/event-machine-skeleton.git <my_project>
-$ cd <my_project>
-$ rm -rf .git
+$ composer create-project proophsoftware/event-machine-skeleton .
 $ docker run --rm -it -v $(pwd):/app prooph/composer:7.1 install
 $ docker-compose up -d
 $ docker-compose run php php scripts/create_event_stream.php


### PR DESCRIPTION
Using `composer create-project` makes it much easier imo.

Another pro for using this method is that it will come without the `.git` folder so no need for a manual removal.

Requires you to submit to packagist, and they will handle the rest.